### PR TITLE
v1.1.0 - Lyrics sync, song controls, tap-to-seek, check for updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,23 @@ Grab the latest APK from [Releases](https://github.com/Avaneesh-Inamdar/FlashLyr
 
 ## Features
 
-### � Light & Dark Mode
+### 🎵 Synced Lyrics with Tap-to-Seek
+
+Real-time synced lyrics that scroll automatically with the music. Tap on any lyric line to jump to that part of the song - just like your favorite streaming apps!
+
+### 🎛️ Song Controls
+
+Control playback directly from the app with the built-in seek bar. Play, pause, and seek to any position in the song without switching apps.
+
+### ⏱️ Lyrics Sync Offset
+
+Adjust the lyrics timing if they appear too early or late. Perfect for songs with unusual timing or when the sync is slightly off.
+
+### 🔄 Check for Updates
+
+Stay up to date with the built-in update checker. Get notified when a new version is available on GitHub.
+
+### 🌓 Light & Dark Mode
 
 Fully supports light and dark themes so it looks great no matter your preference.
 
@@ -48,6 +64,8 @@ Personalize the app with your choice of accent colors to match your style.
 
 - **Auto-detects** the currently playing song using Android's MediaSession
 - **Synced lyrics** that scroll in real time (falls back to plain lyrics)
+- **Tap on lyrics** to seek to that position in the song
+- **Playback controls** with seek bar for manual song navigation
 - Pulls lyrics from **6 different sources** — LRCLIB, Textyl, ChartLyrics, Lyrics.ovh, Lyrist, NetEase
 - **Share lyrics** as a styled image or plain text
 - **Album art** pulled from the playing app

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -58,7 +58,7 @@ class AppConstants {
   AppConstants._();
 
   static const String appName = 'FlashLyrics';
-  static const String appVersion = '1.01';
+  static const String appVersion = '1.1.0';
 
   /// Cache keys
   static const String lyricsCacheKey = 'lyrics_cache';

--- a/lib/presentation/providers/media_provider.dart
+++ b/lib/presentation/providers/media_provider.dart
@@ -205,6 +205,16 @@ class MediaNotifier extends StateNotifier<MediaState> {
     );
   }
 
+  /// Seek to a specific position in the current song
+  Future<bool> seekTo(Duration position) async {
+    return await _service.seekTo(position);
+  }
+
+  /// Play or pause the current song
+  Future<bool> setPlaying(bool playing) async {
+    return await _service.setPlaying(playing);
+  }
+
   @override
   void dispose() {
     _songSubscription?.cancel();

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -15,6 +15,7 @@ class AppSettings {
   final ThemeModeOption themeMode;
   final List<String> providerPriority;
   final String accentColor;
+  final int lyricsSyncOffset; // Offset in milliseconds for lyrics sync
 
   const AppSettings({
     this.fontSize = 18.0,
@@ -23,6 +24,7 @@ class AppSettings {
     this.keepScreenOn = false,
     this.themeMode = ThemeModeOption.auto,
     this.accentColor = 'emerald',
+    this.lyricsSyncOffset = 0,
     this.providerPriority = const [
       'lrclib',
       'textyl',
@@ -72,6 +74,7 @@ class AppSettings {
     ThemeModeOption? themeMode,
     List<String>? providerPriority,
     String? accentColor,
+    int? lyricsSyncOffset,
   }) {
     return AppSettings(
       fontSize: fontSize ?? this.fontSize,
@@ -80,6 +83,7 @@ class AppSettings {
       keepScreenOn: keepScreenOn ?? this.keepScreenOn,
       themeMode: themeMode ?? this.themeMode,
       accentColor: accentColor ?? this.accentColor,
+      lyricsSyncOffset: lyricsSyncOffset ?? this.lyricsSyncOffset,
       providerPriority: providerPriority ?? this.providerPriority,
     );
   }
@@ -91,6 +95,7 @@ class AppSettings {
     'keepScreenOn': keepScreenOn,
     'themeMode': themeMode.name,
     'accentColor': accentColor,
+    'lyricsSyncOffset': lyricsSyncOffset,
     'providerPriority': providerPriority,
   };
 
@@ -117,6 +122,7 @@ class AppSettings {
       keepScreenOn: json['keepScreenOn'] as bool? ?? false,
       themeMode: parseThemeMode(json['themeMode']),
       accentColor: json['accentColor'] as String? ?? 'emerald',
+      lyricsSyncOffset: json['lyricsSyncOffset'] as int? ?? 0,
       providerPriority:
           (json['providerPriority'] as List<dynamic>?)
               ?.map((e) => e as String)
@@ -202,6 +208,11 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   void setAccentColor(String key) {
     state = state.copyWith(accentColor: key);
+    _saveSettings();
+  }
+
+  void setLyricsSyncOffset(int offset) {
+    state = state.copyWith(lyricsSyncOffset: offset);
     _saveSettings();
   }
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -10,6 +10,7 @@ import '../providers/media_provider.dart';
 import '../providers/settings_provider.dart';
 import '../widgets/lyrics_display.dart';
 import '../widgets/song_card.dart';
+import '../widgets/song_controls.dart';
 import '../widgets/permission_card.dart';
 import 'search_screen.dart';
 
@@ -221,6 +222,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             const SizedBox(height: 8),
             SongCard(song: lyricsState.currentSong!),
             const SizedBox(height: 16),
+            // Song controls with seek bar
+            if (mediaState.currentDuration.inMilliseconds > 0)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: SongControls(
+                  currentPosition: mediaState.currentPosition,
+                  totalDuration: mediaState.currentDuration,
+                  isPlaying: mediaState.isPlaying,
+                  onSeek: (position) {
+                    ref.read(mediaNotifierProvider.notifier).seekTo(position);
+                  },
+                  onPlayPause: () {
+                    ref
+                        .read(mediaNotifierProvider.notifier)
+                        .setPlaying(!mediaState.isPlaying);
+                  },
+                ),
+              ),
+            if (mediaState.currentDuration.inMilliseconds > 0)
+              const SizedBox(height: 16),
             if (lyricsState.isLoading && lyricsState.lyrics == null)
               _buildLoadingState()
             else if (lyricsState.error != null && lyricsState.lyrics == null)
@@ -232,6 +253,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                   lyrics: lyricsState.lyrics!,
                   currentPosition: mediaState.currentPosition,
                   isPlaying: mediaState.isPlaying,
+                  onSeek: (position) {
+                    ref.read(mediaNotifierProvider.notifier).seekTo(position);
+                  },
                 ),
               )
             else

--- a/lib/presentation/screens/library_screen.dart
+++ b/lib/presentation/screens/library_screen.dart
@@ -204,12 +204,16 @@ class LibraryScreen extends ConsumerWidget {
     List<dynamic> lyricsList,
     bool isDark,
   ) {
+    // Sort by fetchedAt descending so newest songs appear at the top
+    final sortedList = List<dynamic>.from(lyricsList)
+      ..sort((a, b) => b.fetchedAt.compareTo(a.fetchedAt));
+
     return ListView.builder(
       padding: const EdgeInsets.fromLTRB(20, 8, 20, 100),
       physics: const BouncingScrollPhysics(),
-      itemCount: lyricsList.length,
+      itemCount: sortedList.length,
       itemBuilder: (context, index) {
-        final lyrics = lyricsList[index];
+        final lyrics = sortedList[index];
         return _buildLyricsCard(context, lyrics, index, isDark);
       },
     );

--- a/lib/presentation/widgets/lyrics_display.dart
+++ b/lib/presentation/widgets/lyrics_display.dart
@@ -543,6 +543,7 @@ class _LyricsDisplayState extends ConsumerState<LyricsDisplay> {
     // Dynamic height based on font size (larger fonts need more space)
     final dynamicHeight = 400 + (_syncedFontSize - 14) * 8;
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final settings = ref.watch(settingsProvider);
 
     // Clean minimal styling - no gradients
     final backgroundColor = isDark
@@ -566,6 +567,7 @@ class _LyricsDisplayState extends ConsumerState<LyricsDisplay> {
         isPlaying: widget.isPlaying,
         onSeek: widget.onSeek,
         fontSize: _syncedFontSize,
+        syncOffsetMs: settings.lyricsSyncOffset,
       ),
     ).animate().fadeIn(duration: 400.ms).scale(begin: const Offset(0.98, 0.98));
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -305,7 +305,7 @@ packages:
     source: hosted
     version: "1.0.1"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lyricx
 description: "High-performance Android lyrics app with automatic music detection"
 publish_to: 'none'
-version: 1.0.1+3
+version: 1.1.0+4
 
 environment:
   sdk: ^3.11.0
@@ -22,6 +22,7 @@ dependencies:
   # Network
   dio: ^5.7.0
   connectivity_plus: ^6.1.1
+  http: ^1.2.0
   
   # Local Storage - using shared_preferences for simpler caching
   shared_preferences: ^2.3.3


### PR DESCRIPTION
- Fix critical Android bug: seekToPosition / setPlaybackState used .controller on a MediaController which doesn't exist, causing crash on seek and play/pause
- Lyrics sync: 800ms lead time + user-configurable ±3000ms offset in Settings
- Song controls: seek bar + play/pause button in the home screen
- Tap-to-seek: tapping any synced lyric line seeks the song to that position
- Check for updates: Settings → About; queries GitHub releases API, shows update dialog with release notes and direct download link
- Library: songs now sorted newest-first by fetchedAt timestamp
- Version compare: handles v1.01 style tags (normalizes to semver)
- Fix double Navigator.pop crash in update checker on network errors
- Release notes shown inside update dialog
- Bump version to 1.1.0+4